### PR TITLE
Fix issue with .co.uk/.co.nz multi level tld

### DIFF
--- a/certbot_dns_cpanel/dns_cpanel.py
+++ b/certbot_dns_cpanel/dns_cpanel.py
@@ -167,6 +167,7 @@ class _CPanelClient:
             if record_domain is zone or record_domain.endswith('.' + zone):
                 cpanel_zone = zone
                 cpanel_name = record_domain[:-len(zone)-1]
+                break
 
         if not cpanel_zone:
             raise errors.PluginError("Could not get the zone for %s. Is this name in a zone managed in cPanel?" % record_domain)


### PR DESCRIPTION
Hi @badjware, 

I ran into this issue as @IainKay reported too with my .co.nz domain.   Found the issue was with the iterations in the loop overriding the found zone name.  Fixed by breaking the loop once name is found.  