### PR TITLE
Select the longest matching zone

### DIFF
--- a/certbot_dns_cpanel/dns_cpanel.py
+++ b/certbot_dns_cpanel/dns_cpanel.py
@@ -163,13 +163,11 @@ class _CPanelClient:
         )
         response_data = json.load(response)['cpanelresult']
         logger.debug(response_data)
-        for zone in response_data['data'][0]['zones']:
-            if record_domain is zone or record_domain.endswith('.' + zone):
-                cpanel_zone = zone
-                cpanel_name = record_domain[:-len(zone)-1]
-                break
-
-        if not cpanel_zone:
+        matching_zones = {zone for zone in response_data['data'][0]['zones'] if record_domain == zone or record_domain.endswith('.' + zone)}
+        if matching_zones:
+            cpanel_zone = max(matching_zones, key = len)
+            cpanel_name = record_domain[:-len(cpanel_zone)-1]
+        else:
             raise errors.PluginError("Could not get the zone for %s. Is this name in a zone managed in cPanel?" % record_domain)
 
         return (cpanel_zone, cpanel_name)


### PR DESCRIPTION
If multiple matching zones are returned, take the longest one. This is especially useful if an invalid zone consisting of gTLD and ccTLD is included and the order is not guaranteed.