### PR TITLE
add check for empty zone of a subdomain

### DIFF
--- a/certbot_dns_cpanel/dns_cpanel.py
+++ b/certbot_dns_cpanel/dns_cpanel.py
@@ -277,7 +277,7 @@ class _CPanelClient:
         logger.debug("_get_zone_and_name: url='%s', data='%s', response data='%s'" % (
             self.request_url, json.dumps(data, indent=4),
             json.dumps(response_data, indent=4)))
-        matching_zones = {zone for zone in response_data['data'][0]['zones'] if record_domain == zone or record_domain.endswith('.' + zone)}
+        matching_zones = {zone for zone in response_data['data'][0]['zones'] if response_data['data'][0]['zones'][zone] and (record_domain == zone or record_domain.endswith('.' + zone) ) }
         if matching_zones:
             cpanel_zone = max(matching_zones, key = len)
             cpanel_name = record_domain[:-len(cpanel_zone)-1]


### PR DESCRIPTION
since @mrtimp kindly implemented a much better interface for installer support than I could with my noob coding skills, there is just one change I did which is crucial for my setup (suppose could be others as well) to work
basically if you have a hosted subdomain as below, it is returned in the zones list as an empty zone entry, though it's not possible to add TXT entries to it
"hosted-subdomain.domain.ext": [],
