### PR TITLE
Fix for the subdomain issue

### DIFF
--- a/certbot_dns_cpanel/dns_cpanel.py
+++ b/certbot_dns_cpanel/dns_cpanel.py
@@ -279,7 +279,7 @@ class _CPanelClient:
             json.dumps(response_data, indent=4)))
         matching_zones = {zone for zone in response_data['data'][0]['zones'] if record_domain == zone or record_domain.endswith('.' + zone)}
         if matching_zones:
-            cpanel_zone = max(matching_zones, key = len)
+            cpanel_zone = min(matching_zones, key = len)
             cpanel_name = record_domain[:-len(cpanel_zone)-1]
         else:
             raise errors.PluginError("Could not get the zone for %s. Is this name in a zone managed in cPanel?" % record_domain)


### PR DESCRIPTION
When an account has a domain and a subdomain underneath it, Cpanel API returns them as separate zones (e. g. `test.example.com` and `example.com`). However, it will only let you create an `_acme-challenge.test.example.com` record via adding `_acme-challenge.test` to the `example.com` domain - trying to add `_acme-challenge` to the `test.example.com` errors out.

This PR changes the "find the zone for this domain" logic to look for the topmost (shortest) name.