### PR TITLE
Filter out empty/system DNS zones (without records , no SOA)

### DIFF
--- a/certbot_dns_cpanel/dns_cpanel.py
+++ b/certbot_dns_cpanel/dns_cpanel.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     # python 2
     from urllib import urlencode
-    from urllib2 import urlopen, Request
+    from urllib2 import urlopen, Request # type: ignore
 
 import zope.interface
 
@@ -277,7 +277,11 @@ class _CPanelClient:
         logger.debug("_get_zone_and_name: url='%s', data='%s', response data='%s'" % (
             self.request_url, json.dumps(data, indent=4),
             json.dumps(response_data, indent=4)))
-        matching_zones = {zone for zone in response_data['data'][0]['zones'] if record_domain == zone or record_domain.endswith('.' + zone)}
+        matching_zones = {
+            zone for zone in response_data['data'][0]['zones']
+            if (record_domain == zone or record_domain.endswith('.' + zone))
+            and response_data['data'][0]['zones'][zone]
+        }
         if matching_zones:
             cpanel_zone = max(matching_zones, key = len)
             cpanel_name = record_domain[:-len(cpanel_zone)-1]


### PR DESCRIPTION
Fixes #23 

The changes i made will filter out system created domains so it doesn't match zones without any records, those created by the system when adding a new virtualhost on the Domains page