### PR TITLE
Skip install certificate for default subdomains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,16 @@ credentials.ini
 
 # ---> Intellij IDEs
 /.idea
+
+# Local certbot files and folders
+# These are created when running certbot with
+#   `certbot --work-dir . --config-dir . --logs-dir . ...`
+accounts/
+archive/
+backups/
+csr/
+keys/
+live/
+renewal/
+renewal-hooks/
+letsencrypt.log*

--- a/certbot_dns_cpanel/dns_cpanel.py
+++ b/certbot_dns_cpanel/dns_cpanel.py
@@ -230,6 +230,11 @@ class _CPanelClient:
          :param int fullchain_path:
          """
 
+        default_subdomains = ['autodiscover', 'cpanel', 'cpcalendars', 'cpcontacts', 'mail', 'webdisk', 'webmail']
+        _, cpanel_name = self._get_zone_and_name(record_domain)
+        if cpanel_name in default_subdomains:
+            return
+
         data = self.data.copy()
         data['cpanel_jsonapi_module'] = 'SSL'
         data['cpanel_jsonapi_func'] = 'installssl'


### PR DESCRIPTION
With these change certbot should skip installing the certificate for service subdomains
Beside those listed [here](https://docs.cpanel.net/knowledge-base/general-systems-administration/service-and-proxy-subdomains/), i added `mail` as well to the list as i also see this on my cPanel hosts

This should fix #25 and #22 